### PR TITLE
Upgrade Ruby to 4.0.3, MaglevCMS to 3.0.1, add CI flavor tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: Flavor Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        flavor: [vanilla, maglev]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.flavor }} image
+        run: docker compose build
+        env:
+          JR8_FLAVOR: ${{ matrix.flavor }}
+
+      - name: Start ${{ matrix.flavor }} app
+        run: docker compose up -d
+        env:
+          JR8_FLAVOR: ${{ matrix.flavor }}
+
+      - name: Wait for app to be available (up to 8 min)
+        timeout-minutes: 8
+        run: |
+          until curl -sf http://localhost:3008 -o /dev/null; do
+            sleep 5
+          done
+
+      - name: Root page returns HTTP 200
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3008)
+          echo "HTTP status: $STATUS"
+          [ "$STATUS" = "200" ]
+
+      - name: Maglev editor is accessible
+        if: matrix.flavor == 'maglev'
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L http://localhost:3008/maglev)
+          echo "Maglev editor HTTP status: $STATUS"
+          [ "$STATUS" = "200" ] || [ "$STATUS" = "302" ]
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Stop containers
+        if: always()
+        run: docker compose down -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated Ruby image to 4.0.3 (pinned patch version)
+- Updated MaglevCMS to 3.0.1 (major version — new `maglev:publish_site` step required)
+- Dropped sed workaround for `maglev_client_javascript_tags` (now the canonical helper in 3.x)
+
+### Added
+
+- GitHub Actions CI workflow testing both flavors from scratch to browsable website
+- Local `just-rails-8/test.sh` for end-to-end flavor testing
+
 ## [2.2.0] - 2026-03-24
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,10 @@ docker compose exec web bundle install
 
 ## Important Notes
 
-- **MaglevCMS Version**: Uses version 2.1.0 (latest stable) with official SQLite3 support
-- **MaglevCMS HyperUI Kit**: Updated to 2.0 with vite_ruby pinned to ~> 3.9.0 (3.10.0 has compatibility check that rejects vite-plugin-ruby ^5.1.0)
+- **MaglevCMS Version**: Uses version 3.0.1 (latest stable) with official SQLite3 support
+- **MaglevCMS HyperUI Kit**: Uses 2.0.0 (compatible with MaglevCMS 3.x)
 - **Rails Version**: Pinned to ~> 8.1.3
-- **Database Compatibility**: MaglevCMS 2.1.0 officially supports SQLite3 as an alternative to PostgreSQL
+- **Database Compatibility**: MaglevCMS 3.0.x supports SQLite3 as an alternative to PostgreSQL
 - **Volume Management**: When switching between flavors, clean the environment with `reset.sh` to avoid gem conflicts
 - **Generated Files**: The Rails app is generated in the project root and persisted via volume mounts
 - **Reset Script**: Use `--clean-untracked` flag to remove all untracked files including Rails residue

--- a/just-rails-8/Dockerfile
+++ b/just-rails-8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:4.0-slim
+FROM ruby:4.0.3-slim
 
 # Install system dependencies for Rails
 ENV DEBIAN_FRONTEND=noninteractive

--- a/just-rails-8/setup.sh
+++ b/just-rails-8/setup.sh
@@ -23,7 +23,7 @@ maglev() {
 
   rails new . --database=sqlite3 --skip-action-cable --force
 
-  bundle add maglevcms -v '~> 2.1.0'
+  bundle add maglevcms -v '~> 3.0.0'
   bundle add maglevcms-hyperui-kit -v '~> 2.0.0'
   bundle install
 
@@ -33,12 +33,8 @@ maglev() {
   bundle exec rails g maglev:install
   bundle exec rails g maglev:hyperui:install --force
 
-  # HyperUI Kit 2.0 generates maglev_client_javascript_tags which doesn't
-  # exist in MaglevCMS 2.1.0. Replace with the correct helper.
-  sed -i 's/maglev_client_javascript_tags/maglev_live_preview_client_javascript_tag/' \
-    app/views/theme/layout.html.erb
-
   bundle exec rails maglev:create_site
+  bundle exec rails maglev:publish_site
 }
 
 

--- a/just-rails-8/test.sh
+++ b/just-rails-8/test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# End-to-end test for both JustRails8 flavors.
+# Builds from scratch and verifies each flavor serves a browsable website.
+#
+# Usage:
+#   ./just-rails-8/test.sh              # test both flavors
+#   ./just-rails-8/test.sh vanilla      # test vanilla only
+#   ./just-rails-8/test.sh maglev       # test maglev only
+#
+
+set -euo pipefail
+
+FLAVORS="${*:-vanilla maglev}"
+TIMEOUT=480  # 8 minutes for initial build + boot
+
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; docker compose logs; exit 1; }
+
+wait_for_http() {
+  local deadline=$((SECONDS + TIMEOUT))
+  while [ $SECONDS -lt $deadline ]; do
+    if curl -sf http://localhost:3008 -o /dev/null 2>/dev/null; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+test_flavor() {
+  local flavor=$1
+  echo ""
+  echo "=== Testing $flavor flavor ==="
+
+  ./just-rails-8/reset.sh --clean-untracked
+
+  JR8_FLAVOR=$flavor docker compose up -d
+
+  echo "  Waiting for app (up to ${TIMEOUT}s)..."
+  if wait_for_http; then
+    pass "localhost:3008 is up"
+  else
+    fail "app never became available after ${TIMEOUT}s"
+  fi
+
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3008)
+  [ "$STATUS" = "200" ] && pass "root page returns HTTP 200" || fail "root page returned HTTP $STATUS"
+
+  if [ "$flavor" = "maglev" ]; then
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L http://localhost:3008/maglev)
+    { [ "$STATUS" = "200" ] || [ "$STATUS" = "302" ]; } \
+      && pass "Maglev editor accessible (HTTP $STATUS)" \
+      || fail "Maglev editor returned HTTP $STATUS"
+  fi
+
+  docker compose down -v
+  ./just-rails-8/reset.sh --clean-untracked
+  echo "=== $flavor: PASS ==="
+}
+
+for flavor in $FLAVORS; do
+  test_flavor "$flavor"
+done
+
+echo ""
+echo "All flavor tests passed."


### PR DESCRIPTION
## Summary

- **Ruby 4.0.3**: Pin the Docker base image to a specific patch (`ruby:4.0.3-slim`) for reproducible builds
- **MaglevCMS 3.0.1**: Major version upgrade from 2.1.0. Key changes to setup:
  - New `maglev:publish_site` task is required after `create_site` for the site to serve content
  - `maglev_client_javascript_tags` is now the canonical helper (was `maglev_live_preview_client_javascript_tag` in 2.x) — the sed workaround is removed
- **CI tests**: GitHub Actions matrix runs both `vanilla` and `maglev` flavors on every push and PR, building from scratch and verifying an HTTP 200 root page. Maglev additionally checks the editor is reachable.
- **Local test script**: `just-rails-8/test.sh` for running the same end-to-end check locally

## MaglevCMS 3.x setup changes

MaglevCMS 3.0.1 runtime dependencies: `importmap-rails`, `turbo-rails`, `view_component`, `pagy`, `maglev-injectable`, `class_variants`. All compatible with Rails 8.1.3.

The helper rename is confirmed by reading the MaglevCMS 3.0.1 source — `maglev_live_preview_client_javascript_tag` still exists but now just delegates to `maglev_client_javascript_tags` with a deprecation warning.